### PR TITLE
fix: Update Log4J version to 2.15.0 to patch CVE-2021-44228 critical …

### DIFF
--- a/ECommerce/pom.xml
+++ b/ECommerce/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 		  <groupId>org.apache.logging.log4j</groupId>
 		  <artifactId>log4j-api</artifactId>
-		  <version>2.6.1</version>
+		  <version>2.15.0</version>
 		</dependency>
 		<dependency>
 		  <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Update Log4J version to 2.15.0 to patch CVE-2021-44228 critical vulnerability