### PR TITLE
fix: Update Log4J version to 2.15.0 to patch CVE-2021-44228 critical …

### DIFF
--- a/ECommerce/pom.xml
+++ b/ECommerce/pom.xml
@@ -21,13 +21,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>jstl</groupId>
 			<artifactId>jstl</artifactId>
 			<version>1.2</version>
 		  </dependency>
-		  
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -61,19 +61,19 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-function-deployer</artifactId>
 			<version>3.2.2</version>
-		</dependency>		
+		</dependency>
 
 		<dependency>
 		  <groupId>org.apache.logging.log4j</groupId>
 		  <artifactId>log4j-api</artifactId>
-		  <version>2.6.1</version>
+		  <version>2.15.0</version>
 		</dependency>
 		<dependency>
 		  <groupId>org.apache.logging.log4j</groupId>
 		  <artifactId>log4j-core</artifactId>
-		  <version>2.6.1</version>
+		  <version>2.15.0</version>
 		</dependency>
-	
+
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Update Log4J version to 2.15.0 to patch CVE-2021-44228 critical vulnerability 